### PR TITLE
Add Modal warning test

### DIFF
--- a/client/__test__/ChatPage.test.jsx
+++ b/client/__test__/ChatPage.test.jsx
@@ -4,6 +4,19 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
 import ChatPage from '../src/pages/ChatPage';
 import { useUser } from '../src/context/UserContext';
+import { Modal } from 'antd';
+
+// Mock Ant Design's Modal
+vi.mock('antd', async () => {
+  const actual = await vi.importActual('antd');
+  return {
+    ...actual,
+    Modal: {
+      ...actual.Modal,
+      warning: vi.fn(),
+    },
+  };
+});
 
 // Mock the useUser hook
 vi.mock('../src/context/UserContext', () => ({
@@ -28,8 +41,27 @@ describe('ChatPage Component', () => {
     
         expect(screen.getAllByText(/Virtual Doula/i)).toBeTruthy();
         const chatNowButton = screen.getByRole('button', { name: /Chat Now/i });
-        expect(chatNowButton).toBeTruthy();
-      });;
+      expect(chatNowButton).toBeTruthy();
+    });
+
+    it('calls Modal.warning when "Chat Now" is clicked without a user', () => {
+        useUser.mockReturnValue({
+          user: null,
+          setUser: vi.fn(),
+          login: vi.fn(),
+          logout: vi.fn(),
+        });
+
+        render(
+          <MemoryRouter>
+            <ChatPage />
+          </MemoryRouter>
+        );
+
+        const chatNowButton = screen.getByRole('button', { name: /Chat Now/i });
+        fireEvent.click(chatNowButton);
+        expect(Modal.warning).toHaveBeenCalled();
+      });
 
   it('renders the Chatbot component when user is logged in', () => {
     const mockUser = {


### PR DESCRIPTION
## Summary
- mock Modal.warning in ChatPage tests
- remove stray semicolon
- ensure clicking **Chat Now** without a user triggers a warning

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd4150794832389563581fb3064e7