### PR TITLE
Fix label typo in timeline options

### DIFF
--- a/client/src/components/PlanForm.jsx
+++ b/client/src/components/PlanForm.jsx
@@ -130,23 +130,23 @@ const PlanForm = () => {
   const timelineOptions = [
     {
       value: '6 months',
-      lable: <span>6 months</span>
+      label: <span>6 months</span>
     },
     {
       value: '1 year',
-      lable: <span>1 year</span>
+      label: <span>1 year</span>
     },
     {
       value: '2 years',
-      lable: <span>2 years</span>
+      label: <span>2 years</span>
     },
     {
       value: '5+ years',
-      lable: <span>5+ years</span>
+      label: <span>5+ years</span>
     },
     {
       value: "I don't know",
-      lable: <span>I don't know</span>
+      label: <span>I don't know</span>
     }
   ]
   //<-----------------------additional event handler functions----------------------->//


### PR DESCRIPTION
## Summary
- correct `lable` typo to `label` for timeline options in `PlanForm`

## Testing
- `npm test` within `client` *(fails: vitest not found)*
- `npm test` within `server` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd3fead908323a96603ff4af8ec4d