### PR TITLE
Fix typo comment in openaiRoutes.js

### DIFF
--- a/server/routes/openaiRoutes.js
+++ b/server/routes/openaiRoutes.js
@@ -32,7 +32,7 @@ router.post('/generate/:id', async (req, res) => {
     }
     const user = userProfile.rows[0];
 
-    // AI inegration
+    // AI integration
     const completion = await openai.chat.completions.create({
       model: "gpt-4o",
       messages: [


### PR DESCRIPTION
## Summary
- correct a misspelled comment in `server/routes/openaiRoutes.js`

## Testing
- `npm test` within `server` *(fails: Cannot find module 'jest')*
- `npm test` within `client` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd4015ecc8323a460d0cf425c7c1c