### PR TITLE
Fix startup log typo

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -37,7 +37,7 @@ app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/dist', 'index.html'));
 });
 
-app.listen(PORT, () => console.log(`Server is runnning on port http://localhost:${PORT}`))
+app.listen(PORT, () => console.log(`Server is running on port http://localhost:${PORT}`))
 
 //for testing
 export default app;


### PR DESCRIPTION
## Summary
- fix spelling of `running` in the server startup log message

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684cd387be308323bcd3bf9eee22d0e4