### PR TITLE
Fix JWT token generation

### DIFF
--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -133,7 +133,7 @@ router.post('/signup', async (req, res) => {
      // Generate JWT token
      const token = jwt.sign(
       {
-        id: newUser.id,
+        userId: newUser.user_id,
         email: newUser.email,
       },
       process.env.JWT_SECRET,


### PR DESCRIPTION
## Summary
- corrected JWT payload in signup API to use `userId` so that new users can access protected routes

## Testing
- `npm test --prefix server` *(fails: Cannot find module '/workspace/queer_conceptions/server/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_684cd25b86c083238ef7a6727a3dd564